### PR TITLE
🎨 display a temporary error page instead of killing the application  (#72)

### DIFF
--- a/registration/src/lib/services/ldap/index.ts
+++ b/registration/src/lib/services/ldap/index.ts
@@ -1,0 +1,8 @@
+import client from './client';
+
+export const init = async (): Promise<void> => {
+  await client.initClient();
+	await client.getClient();
+};
+
+export default client;

--- a/registration/src/lib/services/user/index.ts
+++ b/registration/src/lib/services/user/index.ts
@@ -1,7 +1,7 @@
 import { env } from '$env/dynamic/public';
 import { generateNickNames } from '$lib/utils/username';
 import type { User } from '$types';
-import ldapClient from '$services/ldap/client';
+import ldapClient from '$services/ldap';
 import validator from 'validator';
 import logger from '$services/logger';
 

--- a/registration/src/routes/+page.server.ts
+++ b/registration/src/routes/+page.server.ts
@@ -1,5 +1,4 @@
 import type { Actions, PageServerLoad } from './$types';
-import Client from '$lib/services/ldap/client';
 import { send, verify } from '$lib/services/otp';
 import { type Redirect, fail, redirect } from '@sveltejs/kit';
 import { isPhoneValid } from '$lib/utils/phone';
@@ -20,8 +19,6 @@ import { env } from '$env/dynamic/private';
 import logger from '$services/logger';
 
 export const load: PageServerLoad = async ({ locals, url, cookies, request, getClientAddress }) => {
-	await Client.getClient();
-
 	const country = await getUserCountry(
 		request.headers.get('x-forwarded-for') || getClientAddress()
 	);


### PR DESCRIPTION
when an LDAP connection error occurs, display an internal server error page instead of killing the application .

![Screenshot from 2024-03-06 11 16 46](https://github.com/linagora/twake-workplace/assets/6764881/cbff3827-48cb-4aad-86f8-51db363d5ad8)
